### PR TITLE
Also catch PHP 7 undefined errors, not just PHP 8

### DIFF
--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -71,7 +71,7 @@ class Smarty_Internal_ErrorHandler
         }
 
         if ($this->allowUndefinedArrayKeys && preg_match(
-            '/^(Undefined array key|Trying to access array offset on value of type null)/',
+            '/^(Undefined index|Undefined array key|Trying to access array offset on value of type null)/',
             $errstr
         )) {
             return; // suppresses this error


### PR DESCRIPTION
Mentioned in https://github.com/smarty-php/smarty/issues/736

PR clashes with a few other issues/PRs in the error handler, but we'll fix those/this then.